### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS bypass via URL scheme obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** The `generateHtmlMenuTemplate` function constructed a menu of links using `route.url` wrapped only in `escapeHtml`. Since `escapeHtml` merely encodes HTML entities, it permitted dangerous schemes such as `javascript:` and `data:` to be injected directly into the `<a href>` attribute, exposing users to Stored XSS if they clicked on links generated from maliciously named folders or files.
 **Learning:** Entity escaping (like `escapeHtml`) is insufficient to protect `href` or `src` attributes. URL schemes must be strictly validated or sanitized to neutralize active content schemes (`javascript:`, `vbscript:`, `data:`), even in internally generated routing paths.
 **Prevention:** Implement a dedicated URI sanitizer that decodes the URI and enforces safe schemes, or explicitly strips out malicious schemes prior to injecting URLs into HTML attributes.
+
+## 2024-05-24 - [Bypass XSS URL Sanitization]
+**Vulnerability:** XSS bypass via URL scheme obfuscation (e.g., `\x19javascript:`, `java\nscript:`).
+**Learning:** Checking for malicious protocol schemes like `javascript:` using `.trim().startsWith("javascript:")` is flawed. Browsers ignore whitespace and control characters anywhere in the protocol. `.trim()` only strips leading/trailing standard whitespace, allowing attackers to embed control characters or newlines to bypass the validation.
+**Prevention:** Strip all control characters and whitespace characters (`[\x00-\x20\s]`) from the decoded URL string *before* performing the scheme check (e.g., `.startsWith()`). Only perform this destructive stripping on a validation variable, returning the original intact URL if it is determined to be safe.

--- a/generateHtmlTemplate.js
+++ b/generateHtmlTemplate.js
@@ -41,13 +41,19 @@ const escapeHtml = (unsafe) => {
 const sanitizeUrl = (url) => {
   if (url === undefined || url === null) return "";
   try {
-    const decodedUrl = decodeURIComponent(url.toString()).trim().toLowerCase();
+    const decodedUrl = decodeURIComponent(url.toString())
+      .toLowerCase()
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x20\s]/g, "");
     if (decodedUrl.startsWith("javascript:") || decodedUrl.startsWith("data:") || decodedUrl.startsWith("vbscript:")) {
       return "about:blank";
     }
   } catch (e) {
     // If decodeURIComponent fails (e.g., malformed URI), fallback to simple lowercase check
-    const simpleUrl = url.toString().trim().toLowerCase();
+    const simpleUrl = url.toString()
+      .toLowerCase()
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x20\s]/g, "");
     if (simpleUrl.startsWith("javascript:") || simpleUrl.startsWith("data:") || simpleUrl.startsWith("vbscript:")) {
       return "about:blank";
     }

--- a/test/xss.test.js
+++ b/test/xss.test.js
@@ -42,6 +42,9 @@ describe("Security XSS Checks", () => {
         { url: "vbscript:msgbox(\"test\")", name: "test3" },
         { url: "JAVAScript:alert(1)", name: "test4" },
         { url: "javascript%3Aalert(1)", name: "test5" },
+        { url: "\x19javascript:alert(1)", name: "test6" },
+        { url: "java\nscript:alert(1)", name: "test7" },
+        { url: "%00javascript:alert(1)", name: "test8" },
         { url: "/safe/path.html", name: "safe" }
       ]
     };
@@ -52,9 +55,12 @@ describe("Security XSS Checks", () => {
     expect(html).not.toContain("href='vbscript:msgbox(&quot;test&quot;)'");
     expect(html).not.toContain("href='JAVAScript:alert(1)'");
     expect(html).not.toContain("href='javascript%3Aalert(1)'");
+    expect(html).not.toContain("href='&#039;javascript:alert(1)'");
+    expect(html).not.toContain("href='java\nscript:alert(1)'");
+    expect(html).not.toContain("href='%00javascript:alert(1)'");
 
     // Check that it replaced them with about:blank
-    expect(html.match(/href='about:blank'/g).length).toBe(5);
+    expect(html.match(/href='about:blank'/g).length).toBe(8);
     // Check that the safe URL is retained
     expect(html).toContain("href='/safe/path.html'");
   });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `sanitizeUrl` function in `generateHtmlTemplate.js` was vulnerable to XSS bypass. It relied on `.trim().startsWith("javascript:")` to identify malicious schemes. However, `.trim()` only removes standard leading and trailing whitespace. Browsers ignore control characters (like `\x19`, `\x00`) and internal whitespace (like `\n`) anywhere in the URL scheme. An attacker could bypass the filter with payloads like `java\nscript:alert(1)` or `\x19javascript:alert(1)`.
🎯 Impact: Attackers could inject arbitrary JavaScript into generated HTML menus and links, leading to Cross-Site Scripting (XSS) when users click the crafted links.
🔧 Fix: Updated the `sanitizeUrl` validation logic to strip all control characters and whitespace (`/[\x00-\x20\s]/g`) from a local validation string before checking for malicious schemes. The original URL is still returned unmodified if safe. Added an ESLint ignore directive for the control regex rule.
✅ Verification: Added tests to `test/xss.test.js` validating that control character and whitespace bypasses are properly neutralized to `about:blank`. Run `npm run test` or `npx jest` to verify. All tests pass.

---
*PR created automatically by Jules for task [7564090890802019195](https://jules.google.com/task/7564090890802019195) started by @ycechungAI*