### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS bypass in URL protocol validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,7 @@
 **Vulnerability:** The `generateHtmlMenuTemplate` function constructed a menu of links using `route.url` wrapped only in `escapeHtml`. Since `escapeHtml` merely encodes HTML entities, it permitted dangerous schemes such as `javascript:` and `data:` to be injected directly into the `<a href>` attribute, exposing users to Stored XSS if they clicked on links generated from maliciously named folders or files.
 **Learning:** Entity escaping (like `escapeHtml`) is insufficient to protect `href` or `src` attributes. URL schemes must be strictly validated or sanitized to neutralize active content schemes (`javascript:`, `vbscript:`, `data:`), even in internally generated routing paths.
 **Prevention:** Implement a dedicated URI sanitizer that decodes the URI and enforces safe schemes, or explicitly strips out malicious schemes prior to injecting URLs into HTML attributes.
+## 2024-05-24 - URL Sanitization Control Character Bypass
+**Vulnerability:** XSS bypass possible in `sanitizeUrl` using control characters and whitespace (e.g., `java\nscript:alert(1)`).
+**Learning:** URL protocol validation using basic string prefix matching (`startsWith()`) is insufficient. Browsers automatically strip whitespaces and control characters from schemes before execution.
+**Prevention:** Always strip all whitespace and control characters using regex (e.g., `.replace(/[\x00-\x20\s]/g, '')`) from the validation target before checking for dangerous schemes.

--- a/generateHtmlTemplate.js
+++ b/generateHtmlTemplate.js
@@ -41,13 +41,17 @@ const escapeHtml = (unsafe) => {
 const sanitizeUrl = (url) => {
   if (url === undefined || url === null) return "";
   try {
-    const decodedUrl = decodeURIComponent(url.toString()).trim().toLowerCase();
+    let decodedUrl = decodeURIComponent(url.toString()).trim().toLowerCase();
+    // eslint-disable-next-line no-control-regex
+    decodedUrl = decodedUrl.replace(/[\x00-\x20\s]/g, "");
     if (decodedUrl.startsWith("javascript:") || decodedUrl.startsWith("data:") || decodedUrl.startsWith("vbscript:")) {
       return "about:blank";
     }
   } catch (e) {
     // If decodeURIComponent fails (e.g., malformed URI), fallback to simple lowercase check
-    const simpleUrl = url.toString().trim().toLowerCase();
+    let simpleUrl = url.toString().trim().toLowerCase();
+    // eslint-disable-next-line no-control-regex
+    simpleUrl = simpleUrl.replace(/[\x00-\x20\s]/g, "");
     if (simpleUrl.startsWith("javascript:") || simpleUrl.startsWith("data:") || simpleUrl.startsWith("vbscript:")) {
       return "about:blank";
     }

--- a/test/xss.test.js
+++ b/test/xss.test.js
@@ -58,4 +58,24 @@ describe("Security XSS Checks", () => {
     // Check that the safe URL is retained
     expect(html).toContain("href='/safe/path.html'");
   });
+
+  it("Should sanitize URL bypasses containing control characters or whitespace", () => {
+    const { generateHtmlMenuTemplate } = require("../generateHtmlTemplate");
+    const maliciousOptions = {
+      style: "style.css",
+      routeList: [
+        { url: "java\x09script:alert(1)", name: "test1" },
+        { url: "java\nscript:alert(1)", name: "test2" },
+        { url: " java script :alert(1)", name: "test3" },
+        { url: "vbscript\r:msgbox(1)", name: "test4" },
+      ]
+    };
+
+    const html = generateHtmlMenuTemplate(maliciousOptions);
+    expect(html).not.toContain("href='java\x09script:alert(1)'");
+    expect(html).not.toContain("href='java\nscript:alert(1)'");
+    expect(html).not.toContain("href=' java script :alert(1)'");
+    expect(html).not.toContain("href='vbscript\r:msgbox(1)'");
+    expect(html.match(/href='about:blank'/g).length).toBe(4);
+  });
 });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS bypass possible in URL protocol validation. The `sanitizeUrl` function in `generateHtmlTemplate.js` failed to account for whitespace and control characters (e.g. `\n`, `\t`, `\x00`). Browsers strip these automatically and execute the dangerous protocol anyway.
🎯 Impact: Attackers could provide crafted URLs like `java\nscript:alert(1)` which would bypass sanitization and execute malicious JavaScript on the generated static site when clicked.
🔧 Fix: Stripped all characters between `\x00-\x20` and `\s` from the validation variables using `.replace(/[\x00-\x20\s]/g, "")` prior to performing the `startsWith` checks. We disabled the `no-control-regex` linting rule for these specific regex calls.
✅ Verification: Ran `npm run test` which includes new bypass tests in `test/xss.test.js`. Verified the tests pass and no old features were broken.

---
*PR created automatically by Jules for task [6749136100103752055](https://jules.google.com/task/6749136100103752055) started by @ycechungAI*